### PR TITLE
[latte] Use bluetooth-rfkill-event to bring up BT

### DIFF
--- a/patterns/jolla-hw-adaptation-latte.yaml
+++ b/patterns/jolla-hw-adaptation-latte.yaml
@@ -38,6 +38,7 @@ Requires:
 # bluetooth tools
 - bluez5-tools
 - broadcom-bluetooth
+- bluetooth-rfkill-event-hciattach
 
 - pulseaudio-modules-droid-keepalive
 # for audio recording to work:

--- a/sparse/etc/bcm43xx.conf
+++ b/sparse/etc/bcm43xx.conf
@@ -1,0 +1,11 @@
+ [General]
+uart_dev = /dev/ttyHSU0
+type_id = bcm43xx
+baud_rate = 3000000
+flow = 1
+tosleep = 1
+up_hci = 1
+reg_hci = 1
+no_flush = 1
+use_lpm = 1
+bdaddr = /data/misc/bluetooth/bluetooth_bdaddr

--- a/sparse/etc/sysconfig/bluetooth-rfkill-event-hciattach
+++ b/sparse/etc/sysconfig/bluetooth-rfkill-event-hciattach
@@ -1,0 +1,2 @@
+CONFIGFILE="-c /etc/bcm43xx.conf"
+ 

--- a/sparse/lib/systemd/system/bluetooth.target.wants/droid-bt-mac.service
+++ b/sparse/lib/systemd/system/bluetooth.target.wants/droid-bt-mac.service
@@ -1,0 +1,1 @@
+../droid-bt-mac.service

--- a/sparse/lib/systemd/system/bluetooth.target.wants/droid-hci-up.service
+++ b/sparse/lib/systemd/system/bluetooth.target.wants/droid-hci-up.service
@@ -1,1 +1,0 @@
-../droid-hci-up.service

--- a/sparse/lib/systemd/system/droid-bt-mac.service
+++ b/sparse/lib/systemd/system/droid-bt-mac.service
@@ -5,7 +5,7 @@ After=local-fs.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh /usr/bin/droid/droid-hci-up.sh
+ExecStart=/bin/sh /usr/bin/droid/droid-bt-mac.sh
 RemainAfterExit=yes
 TimeoutStartSec=60
 

--- a/sparse/usr/bin/droid/droid-bt-mac.sh
+++ b/sparse/usr/bin/droid/droid-bt-mac.sh
@@ -32,5 +32,3 @@ if [ -e "/data/misc/bluetooth/bluetooth_bdaddr" ]; then
     fi
 fi
 
-/usr/sbin/brcm_patchram_plus --patchram $firmware --no2bytes --baudrate $baudrate --use_baudrate_for_download $device --bd_addr $addr --enable_hci &
-


### PR DESCRIPTION
Use bluetooth-rfkill-event to bring up the hci device and load the
firmware
Change the systemd script to just set the mac address