### PR TITLE
[droid-config-latte] Start sensorfw daemon once the iio devices have been enumerated

### DIFF
--- a/sparse/etc/systemd/system/sensorfwd.service.d/90-boot-order.conf
+++ b/sparse/etc/systemd/system/sensorfwd.service.d/90-boot-order.conf
@@ -1,2 +1,2 @@
 [Unit]
-After=systemd-modules-load.service
+Requires=sensorfwd-iio-start.path

--- a/sparse/lib/systemd/system/graphical.target.wants/sensorfwd-iio-start.path
+++ b/sparse/lib/systemd/system/graphical.target.wants/sensorfwd-iio-start.path
@@ -1,0 +1,1 @@
+/lib/systemd/system/sensorfwd-iio-start.path

--- a/sparse/lib/systemd/system/sensorfwd-iio-start.path
+++ b/sparse/lib/systemd/system/sensorfwd-iio-start.path
@@ -1,0 +1,10 @@
+[Unit]
+Description=Workaround to make sensorfwd start once the iio devices are ready
+Requires=systemd-modules-load.service
+
+[Path]
+Unit=sensorfwd.service
+PathExists=/dev/iio:device1
+
+[Install]
+WantedBy=graphical.target


### PR DESCRIPTION
Previously systemd started up sensorfwd just after systemd-modules-load did its job
which in most cases was before the driver got the time to properly enumerate the iio
devices.

This workaround adds a new systemd path unit watching /dev/iio:device1. Once the device
has been created, sensorfwd is started.

We can reasonably assume that if /dev/iio:device1 exists, the rest of the iio devices do too
and so it's safe to start sensorfwd.

Signed-off-by: Eugenio Paolantonio (g7) <me@medesimo.eu>