### PR TITLE
[sensors] Tag iio devices fo systemd, and require device4 in sensorfwd

### DIFF
--- a/sparse/etc/systemd/system/sensorfwd.service.d/90-boot-order.conf
+++ b/sparse/etc/systemd/system/sensorfwd.service.d/90-boot-order.conf
@@ -1,3 +1,0 @@
-[Unit]
-Requires=systemd-modules-load.service
-ConditionPathExists=/dev/iio:device1

--- a/sparse/lib/systemd/system/sensorfwd-iio-sampling-frequency.service
+++ b/sparse/lib/systemd/system/sensorfwd-iio-sampling-frequency.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=Increases sampling frequency of the IIO accelerometer
-Requires=sensorfwd.service
+Before=sensorfwd.service
+Wants=dev-iio:device4.device
+After=dev-iio:device4.device
+
 
 [Service]
 Type=oneshot

--- a/sparse/lib/udev/rules.d/99-iio.rules
+++ b/sparse/lib/udev/rules.d/99-iio.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="iio", ACTION=="add", TAG+="systemd" 


### PR DESCRIPTION
startup